### PR TITLE
Add Web App Manifest for PWA Support

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -102,6 +102,8 @@ export default function RootLayout({
           <link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144.png" />
           <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png" />
           <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png" />
+          <link rel="manifest" href="/manifest.json" />
+          <meta name="theme-color" content="#ffffff" />
           {preloadResources}
         </head>
         <body className={poppins.variable}>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,62 @@
+{
+  "name": "Namo Amituofo Registration",
+  "short_name": "Namo Amituofo",
+  "description": "Namo Amituofo Registration is a platform for users to register for events.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/apple-touch-icon-57x57.png",
+      "sizes": "57x57",
+      "type": "image/png"
+    },
+    {
+      "src": "/apple-touch-icon-72x72.png",
+      "sizes": "72x72",
+      "type": "image/png"
+    },
+    {
+      "src": "/apple-touch-icon-76x76.png",
+      "sizes": "76x76",
+      "type": "image/png"
+    },
+    {
+      "src": "/apple-touch-icon-114x114.png",
+      "sizes": "114x114",
+      "type": "image/png"
+    },
+    {
+      "src": "/apple-touch-icon-120x120.png",
+      "sizes": "120x120",
+      "type": "image/png"
+    },
+    {
+      "src": "/apple-touch-icon-144x144.png",
+      "sizes": "144x144",
+      "type": "image/png"
+    },
+    {
+      "src": "/apple-touch-icon-152x152.png",
+      "sizes": "152x152",
+      "type": "image/png"
+    },
+    {
+      "src": "/apple-touch-icon-180x180.png",
+      "sizes": "180x180",
+      "type": "image/png"
+    },
+    {
+      "src": "/apple-touch-icon.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/assets/images/logo.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+} 


### PR DESCRIPTION
- Create manifest.json with comprehensive app configuration
- Add theme color and start URL for PWA compatibility
- Include multiple icon sizes for cross-device support
- Link manifest in layout for improved mobile experience