### PR TITLE
feat(register): hide seat capacity indicator on registration form

### DIFF
--- a/components/shared/RegisterFormClient.tsx
+++ b/components/shared/RegisterFormClient.tsx
@@ -548,7 +548,6 @@ const RegisterFormClient = ({ event, initialOrderCount, onRefresh }: RegisterFor
     }
   };
   const isFullyBooked = initialOrderCount >= event.maxSeats;
-  const seatsRemaining = Math.max(0, event.maxSeats - initialOrderCount);
 
   // Update the append function
   const handleAddPerson = () => {
@@ -765,17 +764,6 @@ const RegisterFormClient = ({ event, initialOrderCount, onRefresh }: RegisterFor
             <ChevronLeftIcon className="h-4 w-4 shrink-0" aria-hidden />
             返回活动详情 / Back to event details
           </Link>
-          {!isFullyBooked && event.maxSeats > 0 && (
-            <div
-              className="rounded-lg border border-primary-200 bg-primary-50/90 px-4 py-3 text-sm text-grey-800"
-              role="status"
-              aria-live="polite"
-            >
-              <span className="font-medium text-primary-900">名额 / Capacity: </span>
-              剩余 {seatsRemaining} 席 / {seatsRemaining} seat{seatsRemaining === 1 ? '' : 's'}{' '}
-              remaining（共 {event.maxSeats} / {event.maxSeats} total）
-            </div>
-          )}
         </div>
         <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">


### PR DESCRIPTION
## Summary

Registration no longer shows the bilingual capacity banner (remaining seats / total seats) above the form. Limits still apply server-side and in the UI when adding participants or when an event is fully booked.

## Test plan

- [ ] Open an event registration page that is not full: confirm no capacity strip appears under “Back to event details”.
- [ ] Confirm fully booked events still show the existing contact message.

Made with [Cursor](https://cursor.com)