### PR TITLE
fix(registration): memoize customFields to fix input deletion bug

### DIFF
--- a/components/shared/RegisterFormClient.tsx
+++ b/components/shared/RegisterFormClient.tsx
@@ -237,13 +237,14 @@ const RegisterFormClient = ({ event, initialOrderCount, onRefresh }: RegisterFor
     detectCountry();
   }, [isLoaded, user]);
 
-  const rawCustomFields = (categoryCustomFields[event.category.name as CategoryName] || categoryCustomFields.default) as CustomField[];
-  // Filter out refuge question when admin disabled it (admin chooses per event for 特别节日法会 / 念佛超荐法会)
-  const customFields = (REFUGE_QUESTION_CATEGORIES.includes(event.category.name as CategoryName) && event.showRefugeQuestion === false)
-    ? rawCustomFields.filter((f) => !fieldLooksLikeRefugeQuestion(f))
-    : rawCustomFields;
+  const customFields = useMemo(() => {
+    const raw = (categoryCustomFields[event.category.name as CategoryName] || categoryCustomFields.default) as CustomField[];
+    return (REFUGE_QUESTION_CATEGORIES.includes(event.category.name as CategoryName) && event.showRefugeQuestion === false)
+      ? raw.filter((f) => !fieldLooksLikeRefugeQuestion(f))
+      : raw;
+  }, [event.category.name, event.showRefugeQuestion]);
 
-  const formSchema = createRegistrationFormSchema(customFields);
+  const formSchema = useMemo(() => createRegistrationFormSchema(customFields), [customFields]);
 
   // Helper function to get default country code
   const getDefaultCountry = (country: string | null) => {
@@ -636,7 +637,7 @@ const RegisterFormClient = ({ event, initialOrderCount, onRefresh }: RegisterFor
     () => debounce((values: z.infer<typeof formSchema>) => {
       saveFormData(values);
     }, 1000),
-    []
+    [customFields]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- **Bug**: Users cannot delete characters in form fields (e.g. name). Deleted characters immediately reappear.
- **Root cause**: `customFields` was computed inline on every render, producing a new array reference each time. The cookie-loading `useEffect` had `[customFields, form]` as dependencies, so it re-ran on every render and overwrote the user's current input with stale cookie data.
- **Fix**: Memoize `customFields` and `formSchema` with `useMemo` so references are stable. The cookie-loading effect now only runs when the event category or refuge setting actually changes.

## Test plan
- [ ] Open registration form, type a name, then delete characters — verify they don't reappear
- [ ] Verify form prefill from cookies still works on initial page load
- [ ] Verify refuge question filtering still works for 特别节日法会 / 念佛超荐法会 categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)