### PR TITLE
feat(registration): prefill phone number from cookie across events

### DIFF
--- a/components/shared/RegisterFormClient.tsx
+++ b/components/shared/RegisterFormClient.tsx
@@ -580,13 +580,12 @@ const RegisterFormClient = ({ event, initialOrderCount, onRefresh }: RegisterFor
       try {
         const parsedData = JSON.parse(savedFormData as string);
 
-        const phoneFieldIds = new Set(customFields.filter(f => f.type === 'phone').map(f => f.id));
         const refugeFieldIds = new Set(
           customFields.filter(f => f.type === 'radio' && fieldLooksLikeRefugeQuestion(f)).map(f => f.id)
         );
 
         Object.entries(parsedData).forEach(([fieldId, saved]) => {
-          if (phoneFieldIds.has(fieldId) || refugeFieldIds.has(fieldId)) return;
+          if (refugeFieldIds.has(fieldId)) return;
 
           const currentField = customFields.find(f => f.id === fieldId);
           if (!currentField) return;
@@ -614,13 +613,12 @@ const RegisterFormClient = ({ event, initialOrderCount, onRefresh }: RegisterFor
 
   const saveFormData = (values: z.infer<typeof formSchema>) => {
     const firstPerson = values.groups[0];
-    const phoneFieldIds = new Set(customFields.filter(f => f.type === 'phone').map(f => f.id));
     const refugeFieldIds = new Set(
       customFields.filter(f => f.type === 'radio' && fieldLooksLikeRefugeQuestion(f)).map(f => f.id)
     );
     const fieldsToSave: Record<string, { value: string | boolean; type: string }> = {};
     Object.entries(firstPerson).forEach(([key, value]) => {
-      if (!phoneFieldIds.has(key) && !refugeFieldIds.has(key)) {
+      if (!refugeFieldIds.has(key)) {
         const field = customFields.find(f => f.id === key);
         if (field) {
           fieldsToSave[key] = { value, type: field.type };


### PR DESCRIPTION
## Summary
- Phone numbers are now saved to and restored from the `lastUsedFields` cookie, so returning users get their phone number prefilled across different events.
- Cross-category data pollution is still prevented by the `{value, type}` cookie format — a value saved as type `phone` will only restore into a field that is also type `phone` in the current category.

## Test plan
- [ ] Register for an event, revisit the registration form — verify phone number is prefilled
- [ ] Register for a default category event, then visit a volunteer event (义工招募) — verify the phone number prefills into the correct phone field (ID `3`), not the text field (ID `2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)