### PR TITLE
fix(registration): remove double-counting of cancellations in capacity check

### DIFF
--- a/app/api/cancel-registration/route.ts
+++ b/app/api/cancel-registration/route.ts
@@ -124,18 +124,6 @@ export async function POST(req: NextRequest) {
 
     if (updatedGroup) {
       console.log(`Verified update - group.cancelled: ${updatedGroup.cancelled} (${typeof updatedGroup.cancelled})`);
-      
-      // Update event's max seats atomically
-      // Only update if the cancelled status actually changed
-      if (updatedGroup.cancelled === cancelledBoolean) {
-        const seatChange = cancelledBoolean ? 1 : -1;
-        await Event.findByIdAndUpdate(
-          eventId,
-          { $inc: { maxSeats: seatChange } },
-          { runValidators: true }
-        );
-        console.log(`Updated event maxSeats by ${seatChange}`);
-      }
     }
 
     // CRITICAL: Ensure cache is properly invalidated to prevent stale data

--- a/scripts/fixDataConsistency.ts
+++ b/scripts/fixDataConsistency.ts
@@ -67,22 +67,11 @@ async function fixDataConsistency() {
         await order.save();
       }
 
-      // Calculate what maxSeats should be based on original capacity and cancellations
-      const originalMaxSeats = event.maxSeats + cancelledCount - uncancelledCount;
-      const expectedMaxSeats = originalMaxSeats + cancelledCount;
-
       console.log(`Event stats:`);
       console.log(`  - Uncancelled registrations: ${uncancelledCount}`);
       console.log(`  - Cancelled registrations: ${cancelledCount}`);
       console.log(`  - Current maxSeats: ${event.maxSeats}`);
-      console.log(`  - Expected maxSeats: ${expectedMaxSeats}`);
       console.log(`  - Duplicate queue numbers: ${duplicateQueueNumbers.size}`);
-
-      // Update maxSeats if it's incorrect
-      if (event.maxSeats !== expectedMaxSeats) {
-        console.log(`⚠️  Updating maxSeats from ${event.maxSeats} to ${expectedMaxSeats}`);
-        await Event.findByIdAndUpdate(event._id, { maxSeats: expectedMaxSeats });
-      }
 
       // Report duplicate queue numbers
       if (duplicateQueueNumbers.size > 0) {


### PR DESCRIPTION
## Summary
- Cancellations were double-counted: `createOrder` already excludes cancelled registrations from the count, but the cancel route was also incrementing `maxSeats` — each cancellation opened **2 slots instead of 1**
- For an event with 300 seats and 36 cancellations, `maxSeats` inflated to 336 while uncancelled count dropped to 264, allowing up to 72 new registrations (should have been 36)
- Removed the `$inc: { maxSeats }` from the cancel-registration route and the corresponding flawed logic in the data consistency script

## Test plan
- [ ] Create an event with a small maxSeats (e.g. 5)
- [ ] Register 5 people to fill it
- [ ] Cancel 1 registration, verify only 1 new registration is allowed (not 2)
- [ ] Uncancel that registration, verify it goes back to full
- [ ] Verify maxSeats in the DB stays at the original value (5) throughout

## Note
Events that already have inflated `maxSeats` from past cancellations will need their `maxSeats` manually corrected back to the intended capacity via the admin UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)