### PR TITLE
fix(registration): prevent console errors when page is auto-translated

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -131,6 +131,26 @@ export default function RootLayout({
     }
   `;
 
+  // Prevent React DOM errors when mobile browsers auto-translate the page
+  const googleTranslateFix = `
+    (function () {
+      if (typeof Node === 'undefined' || !Node.prototype || window.__googleTranslateFixApplied) return;
+      var originalRemoveChild = Node.prototype.removeChild;
+      Node.prototype.removeChild = function (child) {
+        if (child.parentNode !== this) return child;
+        return originalRemoveChild.apply(this, arguments);
+      };
+      var originalInsertBefore = Node.prototype.insertBefore;
+      Node.prototype.insertBefore = function (newNode, referenceNode) {
+        if (referenceNode && referenceNode.parentNode !== this) {
+          return this.appendChild(newNode);
+        }
+        return originalInsertBefore.apply(this, arguments);
+      };
+      window.__googleTranslateFixApplied = true;
+    })();
+  `;
+
   // Script to unregister any existing service workers
   const unregisterServiceWorker = `
     if ('serviceWorker' in navigator) {
@@ -167,6 +187,11 @@ export default function RootLayout({
           {/* unregisterServiceWorker script moved below */}
         </head>
         <body className={poppins.variable}>
+          <Script
+            id="google-translate-fix"
+            strategy="beforeInteractive"
+            dangerouslySetInnerHTML={{ __html: googleTranslateFix }}
+          />
           <Script
             id="unregister-service-worker"
             strategy="afterInteractive"

--- a/components/shared/RegisterFormClient.tsx
+++ b/components/shared/RegisterFormClient.tsx
@@ -57,7 +57,6 @@ const isValidPostalCode = async (code: string, country: string) => {
 interface RegisterFormClientProps {
   event: IEvent & { category: { name: CategoryName } }
   initialOrderCount: number
-  onRefresh: () => Promise<void>
 }
 
 const getCountryFromPhoneNumber = (phoneNumber: string | boolean | undefined) => {
@@ -79,7 +78,7 @@ const isGroupEmpty = (group: any, customFields: CustomField[]) => {
   return !nameValue && !phoneValue;
 };
 
-const RegisterFormClient = ({ event, initialOrderCount, onRefresh }: RegisterFormClientProps) => {
+const RegisterFormClient = ({ event, initialOrderCount }: RegisterFormClientProps) => {
   const router = useRouter()
   const { toast } = useToast()
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -502,12 +501,7 @@ const RegisterFormClient = ({ event, initialOrderCount, onRefresh }: RegisterFor
       }
 
       const data = await response.json();
-      
-      // Refresh order count in background so users reach QR page sooner.
-      void onRefresh().catch((refreshError) => {
-        console.error('Error refreshing order count:', refreshError);
-      });
-      
+
       toast({
         title: "成功 / Success",
         description: "报名成功！/ Registration successful!",
@@ -776,7 +770,7 @@ const RegisterFormClient = ({ event, initialOrderCount, onRefresh }: RegisterFor
           outline: none;
         }
       `}</style>
-      <div className="max-w-3xl mx-auto space-y-4">
+      <div className="max-w-3xl mx-auto space-y-4 notranslate" translate="no">
         <div className="flex flex-col gap-3">
           <Link
             href={`/events/details/${event._id}`}

--- a/components/shared/RegisterFormWrapper.tsx
+++ b/components/shared/RegisterFormWrapper.tsx
@@ -41,7 +41,6 @@ function RegisterFormWrapper({
       <RegisterFormClient 
         event={event} 
         initialOrderCount={initialOrderCount}
-        onRefresh={fetchOrderCount}
       />
     </Suspense>
   )

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -37,8 +37,9 @@ const DialogContent = React.forwardRef<
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
+      translate="no"
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-3 border bg-white p-4 sm:p-6 md:p-8 shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-xl",
+        "notranslate fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-3 border bg-white p-4 sm:p-6 md:p-8 shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-xl",
         className
       )}
       {...props}

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -15,8 +15,9 @@ const ToastViewport = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Viewport
     ref={ref}
+    translate="no"
     className={cn(
-      "fixed inset-x-0 top-4 z-[10000] flex max-h-screen w-full flex-col-reverse p-4 sm:inset-auto sm:bottom-4 sm:right-4 sm:top-auto sm:flex-col md:max-w-[480px]",
+      "notranslate fixed inset-x-0 top-4 z-[10000] flex max-h-screen w-full flex-col-reverse p-4 sm:inset-auto sm:bottom-4 sm:right-4 sm:top-auto sm:flex-col md:max-w-[480px]",
       className
     )}
     {...props}
@@ -48,7 +49,8 @@ const Toast = React.forwardRef<
   return (
     <ToastPrimitives.Root
       ref={ref}
-      className={cn(toastVariants({ variant }), className)}
+      translate="no"
+      className={cn("notranslate", toastVariants({ variant }), className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- Fixes console `NotFoundError` (`removeChild` / `insertBefore`) when mobile users submit event registration with Google Translate enabled; registration already succeeded but React crashed during post-submit re-renders.
- Adds a site-wide defensive DOM patch (React-recommended workaround) and marks the registration form, dialogs, and toasts with `translate="no"` / `notranslate` since labels are already bilingual.
- Removes the unnecessary post-submit `onRefresh()` call that could log warnings after navigating to the QR page.

## Root cause
Chrome/Safari translation wraps text nodes in `<font>` tags, which desyncs React’s virtual DOM. Submit triggers loading state, success toast, and navigation — React then fails to reconcile the mutated DOM while the `/api/createOrder` request completes independently.

## Test plan
- [ ] On mobile Chrome, open an event registration page and enable “Translate to English”
- [ ] Fill out and submit the form — registration should succeed with no console errors
- [ ] Confirm success toast appears and user is redirected to `/reg/[id]`
- [ ] Verify duplicate-registration dialog still works when reusing a phone number
- [ ] Confirm registration still works without translation enabled


Made with [Cursor](https://cursor.com)